### PR TITLE
update devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,33 +2,27 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.163.0/containers/docker-existing-dockerfile
 {
 	"name": "Existing Dockerfile",
-
 	// Sets the run context to one level up instead of the .devcontainer folder.
 	"context": "..",
-
 	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 	"dockerFile": "../Dockerfile",
-
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
+	"settings": {
 		"terminal.integrated.shell.linux": null
 	},
-
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
-
+	"extensions": [],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
+	"forwardPorts": [
+		8080,
+		8082
+	],
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
 	// "postCreateCommand": "apt-get update && apt-get install -y curl",
-
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
 	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
 	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,28 +1,28 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.163.0/containers/docker-existing-dockerfile
 {
-	"name": "Existing Dockerfile",
-	// Sets the run context to one level up instead of the .devcontainer folder.
-	"context": "..",
-	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-	"dockerFile": "../Dockerfile",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.shell.linux": null
-	},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [],
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [
-		8080,
-		8082
-	],
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+  "name": "Existing Dockerfile",
+  // Sets the run context to one level up instead of the .devcontainer folder.
+  "context": "..",
+  // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+  "dockerFile": "../Dockerfile",
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": null
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [
+    8080,
+    8082
+  ],
+  // Uncomment the next line to run commands after the container is created - for example installing curl.
+  // "postCreateCommand": "apt-get update && apt-get install -y curl",
+  // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+  // "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+  // Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+  // "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+  // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+  // "remoteUser": "vscode"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,13 @@ ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 
 # Create the user
+# hadolint ignore=DL3008,DL3015
 RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    && apt-get update \
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME
+  && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+  && apt-get update \
+  && apt-get install -y sudo \
+  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+  && chmod 0440 /etc/sudoers.d/$USERNAME
 # -----------END OF RESOLUTION--------
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,24 @@
 FROM golang:1.15-buster AS builder
 LABEL maintainer="stan_gai@hotmail.com"
 LABEL version="v0.1"
+
+# create directory permission denied issue resolution
+# https://code.visualstudio.com/docs/remote/containers-advanced#_adding-a-nonroot-user-to-your-dev-container
+ARG USERNAME=goate
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+# -----------END OF RESOLUTION--------
+
 WORKDIR /app
+
 COPY . .
 RUN go build -o goate ./cmd
 
@@ -12,9 +29,7 @@ FROM debian:buster-slim
 
 COPY --from=builder /app/goate /bin/goate
 
-RUN addgroup goate && useradd -g goate goate
-
-USER goate
+USER ${USERNAME}
 
 ENTRYPOINT [ "goate" ]
 EXPOSE 8080 8082

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An API server serves both HTTP and gRPC services on same port.
 
 ### Required
 
-* __Go__ (v1.13 or above)
+* __Go__ (>= 1.15)
 * __protobuf__
 * __gRPC__
   

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/9c92631cb282462fb2fa5737516ad851)](https://app.codacy.com/manual/user3301/goate?utm_source=github.com&utm_medium=referral&utm_content=user3301/goate&utm_campaign=Badge_Grade_Dashboard)
 
-An API server serves both HTTP and gRPC services on same port.
+An API server uses [gRPC-Gateway](https://github.com/grpc-ecosystem/grpc-gateway) to serve both HTTP and gRPC services on same port.
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@ An API server serves both HTTP and gRPC services on same port.
 * __Go__ (>= 1.15)
 * __protobuf__
 * __gRPC__
-  
+
 ### Optional
 
 * __grpcurl__


### PR DESCRIPTION
This PR updates the `devcontainer` configuration to port-forwarding 8080 and 8082 to local network,
and updates the `Dockerfile` to grant non-root user with sudo access (to get away with create directory permission denied error for devcontainer, details see https://code.visualstudio.com/docs/remote/containers-advanced#_adding-a-nonroot-user-to-your-dev-container).